### PR TITLE
Update calendar_csv.csv

### DIFF
--- a/calendar_csv.csv
+++ b/calendar_csv.csv
@@ -8,7 +8,7 @@ DreamHack Montreal ,https://www.eventhubs.com/events/2017/sep/08/dreamhack-mont
 Manila Cup 2017 ,https://www.eventhubs.com/events/2017/sep/08/manila-cup-2017/,2017-09-08,2017-09-10,"Manila, Philippines","teamsp00ky,playbook_ph"
 Thunderstruck V ,https://www.eventhubs.com/events/2017/sep/15/thunderstruck-v/,2017-09-15,2017-09-17,"Monterrey, Nuevo León",capcomfighters
 OzHadou Nationals 15 ,https://www.eventhubs.com/events/2017/sep/15/ozhadou-nationals-15/,2017-09-15,2017-09-17,"Sydney, New South Wales",capcomfighters
-Brooklyn Beatdown,http://event.eslgaming.com/esloneny/brooklynbeatdown/,2017-09-16,2017-09-17,"Brooklyn, New York",capcomfighters
+Brooklyn Beatdown,http://event.eslgaming.com/esloneny/brooklynbeatdown/,2017-09-16,2017-09-17,"Brooklyn, New York",esl_sfv
 Street Grand Battle ,https://www.eventhubs.com/events/2017/sep/16/street-grand-battle-cpt/,2017-09-16,2017-09-17,"Lyon, France",capcomfighters
 EGX 2017 ,https://www.eventhubs.com/events/2017/sep/21/egx-2017/,2017-09-21,2017-09-24,"Birmingham, England",capcomfighters
 SoCal Regionals 2017 ,https://www.eventhubs.com/events/2017/sep/22/socal-regionals-2017/,2017-09-22,2017-09-24,"Anaheim, California",capcomfighters


### PR DESCRIPTION
last year Brooklyn Beatdown was on ESL_SFV, stands to reason it would stay on there instead of on Capcomfighters (it's not a CPT event iirc)